### PR TITLE
PP-15836 add Dependabot exclude cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
         # org.eclipse.persistence.jpa 5 is incompatible with Guice 7, needs a lot of work on our end
         versions:
           - ">= 5"
+    cooldown:
+      exclude:
+        - "uk.gov.service.payments:*"
   - package-ecosystem: docker
     directory: "/"
     schedule:


### PR DESCRIPTION
## WHAT YOU DID

Exclude pay-java-commons from the cooldown period of dependabot updates.
